### PR TITLE
Keep all peers in routing table

### DIFF
--- a/Libplanet.Seed.Executable/Libplanet.Seed.Executable.csproj
+++ b/Libplanet.Seed.Executable/Libplanet.Seed.Executable.csproj
@@ -3,6 +3,7 @@
     <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU1701,SA1118</NoWarn>
     <CodeAnalysisRuleSet>..\Libplanet.Seed.ruleset</CodeAnalysisRuleSet>

--- a/Libplanet.Seed.Executable/Net/Seed.cs
+++ b/Libplanet.Seed.Executable/Net/Seed.cs
@@ -70,7 +70,7 @@ namespace Libplanet.Seed.Executable.Net
                     Log.Error(
                         "-t/--transport-type must be either \"tcp\" or \"netmq\".");
                     Environment.Exit(1);
-                    return;
+                    throw new ArgumentException(nameof(transportType));
             }
 
             PeerInfos = new ConcurrentDictionary<Address, PeerInfo>();

--- a/Libplanet.Seed.Executable/Net/Seed.cs
+++ b/Libplanet.Seed.Executable/Net/Seed.cs
@@ -1,0 +1,192 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Libplanet.Crypto;
+using Libplanet.Net;
+using Libplanet.Net.Protocols;
+using Libplanet.Net.Transports;
+using Serilog;
+
+namespace Libplanet.Seed.Executable.Net
+{
+    public class Seed
+    {
+        private readonly PrivateKey _privateKey;
+        private readonly KademliaProtocol _kademliaProtocol;
+        private readonly ITransport _transport;
+
+        public Seed(
+            PrivateKey privateKey,
+            string? host,
+            int? port,
+            int workers,
+            IceServer[] iceServers,
+            AppProtocolVersion appProtocolVersion,
+            string transportType)
+        {
+            Table = new RoutingTable(privateKey.ToAddress());
+            _privateKey = privateKey;
+            switch (transportType)
+            {
+                case "tcp":
+                    _transport = new TcpTransport(
+                        Table,
+                        privateKey,
+                        appProtocolVersion,
+                        null,
+                        host: host,
+                        listenPort: port,
+                        iceServers: iceServers,
+                        differentAppProtocolVersionEncountered: null,
+                        minimumBroadcastTarget: 0);
+                    break;
+                case "netmq":
+                    _transport = new NetMQTransport(
+                        Table,
+                        privateKey,
+                        appProtocolVersion,
+                        null,
+                        workers: workers,
+                        host: host,
+                        listenPort: port,
+                        iceServers: iceServers,
+                        differentAppProtocolVersionEncountered: null,
+                        minimumBroadcastTarget: 0);
+                    break;
+                default:
+                    Log.Error(
+                        "-t/--transport-type must be either \"tcp\" or \"netmq\".");
+                    Environment.Exit(1);
+                    return;
+            }
+
+            _kademliaProtocol = new KademliaProtocol(
+                Table,
+                _transport,
+                privateKey.ToAddress());
+        }
+
+        public RoutingTable Table { get; }
+
+        public async Task StartAsync(
+            HashSet<BoundPeer> staticPeers,
+            CancellationToken cancellationToken)
+        {
+            var tasks = new List<Task>
+            {
+                StartTransportAsync(cancellationToken),
+                RefreshTableAsync(cancellationToken),
+                RebuildConnectionAsync(cancellationToken),
+            };
+            if (staticPeers.Any())
+            {
+                tasks.Add(CheckStaticPeersAsync(staticPeers, cancellationToken));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        public async Task StopAsync(TimeSpan waitFor)
+        {
+            await _transport.StopAsync(waitFor);
+        }
+
+        private async Task StartTransportAsync(CancellationToken cancellationToken)
+        {
+            await _transport.StartAsync(cancellationToken);
+            Task task = _transport.StartAsync(cancellationToken);
+            await _transport.WaitForRunningAsync();
+            await task;
+        }
+
+        private async Task RefreshTableAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+                    await _kademliaProtocol.RefreshTableAsync(
+                        TimeSpan.FromSeconds(60),
+                        cancellationToken);
+                    await _kademliaProtocol.CheckReplacementCacheAsync(cancellationToken);
+                }
+                catch (OperationCanceledException e)
+                {
+                    Log.Warning(e, $"{nameof(RefreshTableAsync)}() is cancelled.");
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    var msg = "Unexpected exception occurred during " +
+                              $"{nameof(RefreshTableAsync)}(): {{0}}";
+                    Log.Warning(e, msg, e);
+                }
+            }
+        }
+
+        private async Task RebuildConnectionAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromMinutes(10), cancellationToken);
+                    await _kademliaProtocol.RebuildConnectionAsync(
+                        Kademlia.MaxDepth,
+                        cancellationToken);
+                }
+                catch (OperationCanceledException e)
+                {
+                    Log.Warning(e, "{FName}() is cancelled.", nameof(RebuildConnectionAsync));
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    Log.Error(
+                        e,
+                        "Unexpected exception occurred during {FName}()",
+                        nameof(RebuildConnectionAsync));
+                }
+            }
+        }
+
+        private async Task CheckStaticPeersAsync(
+            IEnumerable<BoundPeer> peers,
+            CancellationToken cancellationToken)
+        {
+            var boundPeers = peers as BoundPeer[] ?? peers.ToArray();
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+                    Log.Warning("Checking static peers. {@Peers}", boundPeers);
+                    var peersToAdd = boundPeers.Where(peer => !Table.Contains(peer)).ToArray();
+                    if (peersToAdd.Any())
+                    {
+                        Log.Warning("Some of peers are not in routing table. {@Peers}", peersToAdd);
+                        await _kademliaProtocol.AddPeersAsync(
+                            peersToAdd,
+                            TimeSpan.FromSeconds(5),
+                            cancellationToken);
+                    }
+                }
+                catch (OperationCanceledException e)
+                {
+                    Log.Warning(e, $"{nameof(CheckStaticPeersAsync)}() is cancelled.");
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    var msg = "Unexpected exception occurred during " +
+                              $"{nameof(CheckStaticPeersAsync)}(): {{0}}";
+                    Log.Warning(e, msg, e);
+                }
+            }
+        }
+    }
+}

--- a/Libplanet.Seed.Executable/Net/Seed.cs
+++ b/Libplanet.Seed.Executable/Net/Seed.cs
@@ -212,12 +212,12 @@ namespace Libplanet.Seed.Executable.Net
                         .Select(state => state.BoundPeer)
                         .Take(_maximumPeersToRefresh)
                         .ToArray();
+                    _logger.Debug(
+                        "Refreshing peers in table. (Total: {Total}, Candidate: {Candidate})",
+                        Peers.Count(),
+                        peersToUpdate.Length);
                     if (peersToUpdate.Any())
                     {
-                        _logger.Debug(
-                            "Refreshing peers in table. (Total: {Total}, Candidate: {Candidate})",
-                            Peers.Count(),
-                            peersToUpdate.Length);
                         await AddPeersAsync(
                             peersToUpdate.ToArray(),
                             _pingTimeout,

--- a/Libplanet.Seed.Executable/Net/Seed.cs
+++ b/Libplanet.Seed.Executable/Net/Seed.cs
@@ -67,10 +67,9 @@ namespace Libplanet.Seed.Executable.Net
                         differentAppProtocolVersionEncountered: null);
                     break;
                 default:
-                    Log.Error(
-                        "-t/--transport-type must be either \"tcp\" or \"netmq\".");
-                    Environment.Exit(1);
-                    throw new ArgumentException(nameof(transportType));
+                    throw new ArgumentException(
+                        "-t/--transport-type must be either \"tcp\" or \"netmq\".",
+                        nameof(transportType));
             }
 
             PeerInfos = new ConcurrentDictionary<Address, PeerInfo>();
@@ -106,12 +105,11 @@ namespace Libplanet.Seed.Executable.Net
             await _transport.StopAsync(waitFor);
         }
 
-        private async Task StartTransportAsync(CancellationToken cancellationToken)
+        private async Task<Task> StartTransportAsync(CancellationToken cancellationToken)
         {
-            await _transport.StartAsync(cancellationToken);
             Task task = _transport.StartAsync(cancellationToken);
             await _transport.WaitForRunningAsync();
-            await task;
+            return task;
         }
 
         private async Task ReceiveMessageAsync(Message message)
@@ -165,6 +163,10 @@ namespace Libplanet.Seed.Executable.Net
                     }
                     catch (OperationCanceledException)
                     {
+                        _logger.Information(
+                            "Operation canceled during {FName}().",
+                            nameof(AddPeersAsync),
+                            peer);
                         throw;
                     }
                     catch (Exception e)
@@ -226,6 +228,9 @@ namespace Libplanet.Seed.Executable.Net
                 }
                 catch (OperationCanceledException)
                 {
+                    Log.Information(
+                        "Operation canceled during {FName}().",
+                        nameof(RefreshTableAsync));
                     throw;
                 }
                 catch (Exception e)
@@ -261,6 +266,9 @@ namespace Libplanet.Seed.Executable.Net
                 }
                 catch (OperationCanceledException)
                 {
+                    Log.Information(
+                        "Operation canceled during {FName}().",
+                        nameof(CheckStaticPeersAsync));
                     throw;
                 }
                 catch (Exception e)

--- a/Libplanet.Seed.Executable/Net/Seed.cs
+++ b/Libplanet.Seed.Executable/Net/Seed.cs
@@ -189,7 +189,11 @@ namespace Libplanet.Seed.Executable.Net
             return PeerInfos.AddOrUpdate(
                 peer.Address,
                 peerInfo,
-                (address, info) => peerInfo);
+                (address, info) =>
+                {
+                    peerInfo.Latency = latency ?? info.Latency;
+                    return peerInfo;
+                });
         }
 
         private async Task RefreshTableAsync(CancellationToken cancellationToken)

--- a/Libplanet.Seed.Executable/Options.cs
+++ b/Libplanet.Seed.Executable/Options.cs
@@ -14,6 +14,7 @@ namespace Libplanet.Seed.Executable
         [Option(
             'l',
             "log-level",
+            Required = false,
             Default = "information",
             HelpText = "Minimum severity for logging. " +
                        "Should be one of error, warning, information, debug, verbose.")]
@@ -22,6 +23,7 @@ namespace Libplanet.Seed.Executable
         [Option(
             'h',
             "host",
+            Required = false,
             Default = null,
             HelpText = "The host address to listen.")]
         public string? Host { get; set; }
@@ -29,6 +31,7 @@ namespace Libplanet.Seed.Executable
         [Option(
             'p',
             "port",
+            Required = false,
             Default = null,
             HelpText = "The port number to listen.")]
         public int? Port { get; set; }
@@ -36,6 +39,7 @@ namespace Libplanet.Seed.Executable
         [Option(
             'w',
             "workers",
+            Required = false,
             Default = 30,
             HelpText = "The number of concurrent message processing workers. " +
                 "Ignored if transport type is set to \"tcp\".")]
@@ -44,6 +48,7 @@ namespace Libplanet.Seed.Executable
         [Option(
             'H',
             "graphql-host",
+            Required = false,
             Default = "localhost",
             HelpText = "The host address to listen graphql queries.")]
         public string? GraphQLHost { get; set; }
@@ -51,6 +56,7 @@ namespace Libplanet.Seed.Executable
         [Option(
             'P',
             "graphql-port",
+            Required = false,
             Default = 5000,
             HelpText = "The port number to listen graphql queries.")]
         public int GraphQLPort { get; set; }
@@ -58,13 +64,14 @@ namespace Libplanet.Seed.Executable
         [Option(
             'V',
             "app-protocol-version",
-            HelpText = "An app protocol version token.",
-            Required = true)]
+            Required = true,
+            HelpText = "An app protocol version token.")]
         public string? AppProtocolVersionToken { get; set; }
 
         [Option(
             't',
             "transport-type",
+            Required = false,
             Default = "tcp",
             HelpText = "The type of transport to use. Should be either \"tcp\" or \"netmq\".")]
         public string TransportType { get; set; } = "tcp";
@@ -72,6 +79,7 @@ namespace Libplanet.Seed.Executable
         [Option(
             'k',
             "private-key",
+            Required = true,
             HelpText = "Private key used for node identifying and message signing.")]
         public string PrivateKeyString
         {
@@ -100,6 +108,8 @@ namespace Libplanet.Seed.Executable
         [Option(
             'I',
             "ice-server",
+            Required = false,
+            Default = "",
             HelpText = "URL to ICE server (TURN/STUN) to work around NAT.")]
         public string IceServerUrl
         {
@@ -121,10 +131,12 @@ namespace Libplanet.Seed.Executable
 
         [Option(
             longName: "peers",
+            Required = false,
+            Default = new string[] { },
             HelpText = "A list of peers that must exist in the peer table. " +
                        "The format of each peer is a comma-separated triple of a peer's " +
                        "hexadecimal public key, host, and port number.")]
-        public IEnumerable<string>? PeerStrings
+        public IEnumerable<string> PeerStrings
         {
             get
             {
@@ -133,12 +145,6 @@ namespace Libplanet.Seed.Executable
 
             set
             {
-                if (value is null)
-                {
-                    Peers = new BoundPeer[] { };
-                    return;
-                }
-
                 Peers = value.Select(str =>
                 {
                     string[] parts = str.Split(',');
@@ -156,7 +162,37 @@ namespace Libplanet.Seed.Executable
             }
         }
 
-        public IEnumerable<BoundPeer> Peers { get; set; } = new BoundPeer[] { };
+        public IEnumerable<BoundPeer> Peers { get; private set; } = new BoundPeer[] { };
+
+        [Option(
+            longName: "maximumPeersToRefresh",
+            Required = false,
+            Default = int.MaxValue,
+            HelpText = "Maximum number of peers to be refreshed at once " +
+                       "in periodic peer table refreshing task.")]
+        public int MaximumPeersToRefresh { get; set; }
+
+        [Option(
+            longName: "refreshInterval",
+            Required = false,
+            Default = 120,
+            HelpText = "Period in second of the peer table refreshing task.")]
+        public int RefreshInterval { get; set; }
+
+        [Option(
+            longName: "peerLifetime",
+            Required = false,
+            Default = 120,
+            HelpText = "Lifespan by second determining whether " +
+                       "a peer is stale and needs refreshing.")]
+        public int PeerLifetime { get; set; }
+
+        [Option(
+            longName: "pingTimeout",
+            Required = false,
+            Default = 5,
+            HelpText = "Timeout by second of reply to the pong message.")]
+        public int PingTimeout { get; set; }
 
         public static Options Parse(string[] args, TextWriter errorWriter)
         {

--- a/Libplanet.Seed.Executable/Options.cs
+++ b/Libplanet.Seed.Executable/Options.cs
@@ -217,7 +217,9 @@ namespace Libplanet.Seed.Executable
                 );
             }
 
-            throw new Exception("Unexpected error occurred parsing arguments.");
+            throw new ArgumentException(
+                "Unexpected error occurred parsing arguments.",
+                nameof(args));
         }
     }
 }

--- a/Libplanet.Seed.Executable/Options.cs
+++ b/Libplanet.Seed.Executable/Options.cs
@@ -165,7 +165,7 @@ namespace Libplanet.Seed.Executable
         public IEnumerable<BoundPeer> Peers { get; private set; } = new BoundPeer[] { };
 
         [Option(
-            longName: "maximumPeersToRefresh",
+            longName: "maximum-peers-to-refresh",
             Required = false,
             Default = int.MaxValue,
             HelpText = "Maximum number of peers to be refreshed at once " +
@@ -173,14 +173,14 @@ namespace Libplanet.Seed.Executable
         public int MaximumPeersToRefresh { get; set; }
 
         [Option(
-            longName: "refreshInterval",
+            longName: "refresh-interval",
             Required = false,
-            Default = 120,
+            Default = 5,
             HelpText = "Period in second of the peer table refreshing task.")]
         public int RefreshInterval { get; set; }
 
         [Option(
-            longName: "peerLifetime",
+            longName: "peer-lifetime",
             Required = false,
             Default = 120,
             HelpText = "Lifespan by second determining whether " +
@@ -188,7 +188,7 @@ namespace Libplanet.Seed.Executable
         public int PeerLifetime { get; set; }
 
         [Option(
-            longName: "pingTimeout",
+            longName: "ping-timeout",
             Required = false,
             Default = 5,
             HelpText = "Timeout by second of reply to the pong message.")]

--- a/Libplanet.Seed.Executable/Options.cs
+++ b/Libplanet.Seed.Executable/Options.cs
@@ -6,7 +6,6 @@ using System.Net;
 using CommandLine;
 using Libplanet.Crypto;
 using Libplanet.Net;
-using Serilog;
 
 namespace Libplanet.Seed.Executable
 {
@@ -18,14 +17,14 @@ namespace Libplanet.Seed.Executable
             Default = "information",
             HelpText = "Minimum severity for logging. " +
                        "Should be one of error, warning, information, debug, verbose.")]
-        public string LogLevel { get; set; }
+        public string? LogLevel { get; set; }
 
         [Option(
             'h',
             "host",
             Default = null,
             HelpText = "The host address to listen.")]
-        public string Host { get; set; }
+        public string? Host { get; set; }
 
         [Option(
             'p',
@@ -47,7 +46,7 @@ namespace Libplanet.Seed.Executable
             "graphql-host",
             Default = "localhost",
             HelpText = "The host address to listen graphql queries.")]
-        public string GraphQLHost { get; set; }
+        public string? GraphQLHost { get; set; }
 
         [Option(
             'P',
@@ -57,25 +56,18 @@ namespace Libplanet.Seed.Executable
         public int GraphQLPort { get; set; }
 
         [Option(
-            'M',
-            "minimum-broadcast-target",
-            Default = 10,
-            HelpText = "The number of minimum targets to broadcast.")]
-        public int MinimumBroadcastTarget { get; set; }
-
-        [Option(
             'V',
             "app-protocol-version",
             HelpText = "An app protocol version token.",
             Required = true)]
-        public string AppProtocolVersionToken { get; set; }
+        public string? AppProtocolVersionToken { get; set; }
 
         [Option(
             't',
             "transport-type",
             Default = "tcp",
             HelpText = "The type of transport to use. Should be either \"tcp\" or \"netmq\".")]
-        public string TransportType { get; set; }
+        public string TransportType { get; set; } = "tcp";
 
         [Option(
             'k',
@@ -83,8 +75,6 @@ namespace Libplanet.Seed.Executable
             HelpText = "Private key used for node identifying and message signing.")]
         public string PrivateKeyString
         {
-            get => PrivateKey is null ? string.Empty : PrivateKey.ToString();
-
             set
             {
                 PrivateKey = null;
@@ -105,7 +95,7 @@ namespace Libplanet.Seed.Executable
             }
         }
 
-        public PrivateKey PrivateKey { get; set; }
+        public PrivateKey? PrivateKey { get; set; }
 
         [Option(
             'I',
@@ -113,25 +103,9 @@ namespace Libplanet.Seed.Executable
             HelpText = "URL to ICE server (TURN/STUN) to work around NAT.")]
         public string IceServerUrl
         {
-            get
-            {
-                if (IceServer is null)
-                {
-                    return null;
-                }
-
-                Uri uri = IceServer.Urls.First();
-                var uriBuilder = new UriBuilder(uri)
-                {
-                    UserName = IceServer.Username,
-                    Password = IceServer.Credential,
-                };
-                return uriBuilder.Uri.ToString();
-            }
-
             set
             {
-                if (value is null)
+                if (string.IsNullOrEmpty(value))
                 {
                     IceServer = null;
                     return;
@@ -143,25 +117,25 @@ namespace Libplanet.Seed.Executable
             }
         }
 
-        public IceServer IceServer { get; set; }
+        public IceServer? IceServer { get; set; }
 
         [Option(
             longName: "peers",
             HelpText = "A list of peers that must exist in the peer table. " +
                        "The format of each peer is a comma-separated triple of a peer's " +
                        "hexadecimal public key, host, and port number.")]
-        public IEnumerable<string> PeerStrings
+        public IEnumerable<string>? PeerStrings
         {
             get
             {
-                return Peers?.Select(peer => peer.ToString());
+                return Peers.Select(peer => peer.ToString());
             }
 
             set
             {
                 if (value is null)
                 {
-                    Peers = null;
+                    Peers = new BoundPeer[] { };
                     return;
                 }
 
@@ -182,7 +156,7 @@ namespace Libplanet.Seed.Executable
             }
         }
 
-        public IEnumerable<BoundPeer> Peers { get; set; }
+        public IEnumerable<BoundPeer> Peers { get; set; } = new BoundPeer[] { };
 
         public static Options Parse(string[] args, TextWriter errorWriter)
         {
@@ -199,14 +173,15 @@ namespace Libplanet.Seed.Executable
                 Options options = parsed.Value;
                 return options;
             }
-            else if (result is NotParsed<Options> notParsed)
+
+            if (result is NotParsed<Options> notParsed)
             {
                 System.Environment.Exit(
                     notParsed.Errors.All(e => e.Tag is ErrorType.HelpRequestedError) ? 0 : 1
                 );
             }
 
-            return null;
+            throw new Exception("Unexpected error occurred parsing arguments.");
         }
     }
 }

--- a/Libplanet.Seed.Executable/Program.cs
+++ b/Libplanet.Seed.Executable/Program.cs
@@ -56,11 +56,10 @@ namespace Libplanet.Seed.Executable
 
             if (options.IceServer is null && options.Host is null)
             {
-                Log.Error(
-                    "-h/--host is required if -I/--ice-server is not given."
+                throw new ArgumentException(
+                    "-h/--host is required if -I/--ice-server is not given.",
+                    nameof(options.Host)
                 );
-                Environment.Exit(1);
-                return;
             }
 
             if (!(options.IceServer is null || options.Host is null))

--- a/Libplanet.Seed.Executable/Program.cs
+++ b/Libplanet.Seed.Executable/Program.cs
@@ -78,7 +78,11 @@ namespace Libplanet.Seed.Executable
                     options.Workers,
                     options.IceServer is null ? new IceServer[] { } : new[] { options.IceServer },
                     AppProtocolVersion.FromToken(options.AppProtocolVersionToken),
-                    options.TransportType);
+                    options.TransportType,
+                    maximumPeersToToRefresh: options.MaximumPeersToRefresh,
+                    refreshInterval: TimeSpan.FromSeconds(options.RefreshInterval),
+                    peerLifetime: TimeSpan.FromSeconds(options.PeerLifetime),
+                    pingTimeout: TimeSpan.FromSeconds(options.PingTimeout));
                 Startup.Seed = seed;
 
                 IWebHost webHost = WebHost.CreateDefaultBuilder()

--- a/Libplanet.Seed/Controllers/GraphQLBody.cs
+++ b/Libplanet.Seed/Controllers/GraphQLBody.cs
@@ -4,8 +4,8 @@ namespace Libplanet.Seed.Controllers
 {
     public class GraphQLBody
     {
-        public string Query { get; set; }
+        public string? Query { get; set; }
 
-        public JObject Variables { get; set; }
+        public JObject? Variables { get; set; }
     }
 }

--- a/Libplanet.Seed/GraphTypes/PeerInfoType.cs
+++ b/Libplanet.Seed/GraphTypes/PeerInfoType.cs
@@ -1,35 +1,30 @@
 ﻿using System;
 using GraphQL.Types;
-using Libplanet.Net;
+using Libplanet.Seed.Interfaces;
 
 namespace Libplanet.Seed.GraphTypes
 {
-    public class PeerStateType : ObjectGraphType<PeerState>
+    public class PeerInfoType : ObjectGraphType<PeerInfo>
     {
-        public PeerStateType()
+        public PeerInfoType()
         {
             Field(
                 name: "address",
-                x => x.Peer.Address,
+                x => x.BoundPeer.Address,
                 type: typeof(NonNullGraphType<IdGraphType>));
             Field(
                 name: "endPoint",
-                x => x.Peer.EndPoint,
+                x => x.BoundPeer.EndPoint,
                 type: typeof(NonNullGraphType<IdGraphType>));
             Field(
                 name: "publicIPAddress",
-                x => x.Peer.PublicIPAddress,
+                x => x.BoundPeer.PublicIPAddress,
                 nullable: true,
                 type: typeof(IdGraphType));
             Field(
                 name: "lastUpdated",
                 x => x.LastUpdated,
                 type: typeof(NonNullGraphType<IdGraphType>));
-            Field(
-                name: "lastChecked",
-                x => x.LastChecked,
-                nullable: true,
-                type: typeof(IdGraphType));
             Field(
                 name: "latency",
                 x => x.Latency,

--- a/Libplanet.Seed/Interfaces/IContext.cs
+++ b/Libplanet.Seed/Interfaces/IContext.cs
@@ -1,13 +1,14 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using GraphQL.Types;
-using Libplanet.Net.Protocols;
 using Libplanet.Seed.Queries;
 
 namespace Libplanet.Seed.Interfaces
 {
     public interface IContext
     {
-        RoutingTable Table { get; }
+        ConcurrentDictionary<Address, PeerInfo>? Peers { get; }
     }
 
     public static class SeedContext
@@ -21,7 +22,10 @@ namespace Libplanet.Seed.Interfaces
                 context,
                 (_) =>
                 {
-                    var s = new Schema { Query = new Query(context.Table) };
+                    var s = new Schema
+                    {
+                        Query = new Query(context.Peers),
+                    };
                     return s;
                 });
         }

--- a/Libplanet.Seed/Libplanet.Seed.csproj
+++ b/Libplanet.Seed/Libplanet.Seed.csproj
@@ -3,6 +3,7 @@
     <LangVersion>8.0</LangVersion>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Libplanet.Seed</RootNamespace>
+    <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU1701</NoWarn>
     <CodeAnalysisRuleSet>..\Libplanet.Seed.ruleset</CodeAnalysisRuleSet>

--- a/Libplanet.Seed/PeerInfo.cs
+++ b/Libplanet.Seed/PeerInfo.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Libplanet.Net;
+
+namespace Libplanet.Seed
+{
+    public struct PeerInfo
+    {
+        public BoundPeer BoundPeer;
+        public DateTimeOffset LastUpdated;
+        public TimeSpan? Latency;
+    }
+}

--- a/Libplanet.Seed/Queries/Query.cs
+++ b/Libplanet.Seed/Queries/Query.cs
@@ -1,25 +1,17 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
 using GraphQL.Types;
-using Libplanet.Net;
-using Libplanet.Net.Protocols;
 using Libplanet.Seed.GraphTypes;
 
 namespace Libplanet.Seed.Queries
 {
     public class Query : ObjectGraphType
     {
-        private static RoutingTable _table;
-
-        public Query(RoutingTable table)
+        public Query(ConcurrentDictionary<Address, PeerInfo>? peers)
         {
-            _table = table;
-
-            Field<NonNullGraphType<ListGraphType<NonNullGraphType<PeerStateType>>>>(
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<PeerInfoType>>>>(
                 "peers",
-                resolve: _ => ListPeers
+                resolve: _ => peers?.Values
             );
         }
-
-        internal static IEnumerable<PeerState> ListPeers => _table.PeerStates;
     }
 }


### PR DESCRIPTION
This PR addresses huge change to the seed structure, mainly routing table. No more uses `RoutingTable` in `Libplanet.Net`, instead  just uses a `ConcurrentDictionary<Address, PeerInfo>` (`PeerInfo` is also newly defined structure because `PeerState` in Libplanet.Net` is defined as `internal` class.

When any peer request neighbors via `FindNeighbors` message, seed will pass all peers in the dictionary (before was peers were chosen by `KademliaProtocol`).