### PR TITLE
Update Libplanet.Net 0.53.4

### DIFF
--- a/Libplanet.Seed.Executable/Libplanet.Seed.Executable.csproj
+++ b/Libplanet.Seed.Executable/Libplanet.Seed.Executable.csproj
@@ -29,7 +29,7 @@
       </IncludeAssets>
     </PackageReference>
     <PackageReference Include="CommandLineParser" Version="2.6.0" />
-    <PackageReference Include="Libplanet.Net" Version="0.46.0" />
+    <PackageReference Include="Libplanet.Net" Version="0.53.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libplanet.Seed.Executable/Net/Seed.cs
+++ b/Libplanet.Seed.Executable/Net/Seed.cs
@@ -92,18 +92,22 @@ namespace Libplanet.Seed.Executable.Net
 
         private async Task ReceiveMessageAsync(Message message)
         {
-            switch (message)
+            switch (message.Content)
             {
                 case FindNeighborsMsg findNeighbors:
-                    var neighbors = new NeighborsMsg(Peers) { Identity = findNeighbors.Identity };
+                    var neighbors = new NeighborsMsg(Peers);
                     await _transport.ReplyMessageAsync(
                         neighbors,
+                        message.Identity,
                         _runtimeCancellationTokenSource.Token);
                     break;
 
                 default:
-                    var pong = new PongMsg { Identity = message.Identity };
-                    await _transport.ReplyMessageAsync(pong, _runtimeCancellationTokenSource.Token);
+                    var pong = new PongMsg();
+                    await _transport.ReplyMessageAsync(
+                        pong,
+                        message.Identity,
+                        _runtimeCancellationTokenSource.Token);
                     break;
             }
 
@@ -143,7 +147,7 @@ namespace Libplanet.Seed.Executable.Net
                         TimeSpan elapsed = stopwatch.Elapsed;
                         stopwatch.Stop();
 
-                        if (reply is PongMsg)
+                        if (reply.Content is PongMsg)
                         {
                             AddOrUpdate(peer, elapsed);
                             success.Add(peer);

--- a/Libplanet.Seed/Libplanet.Seed.csproj
+++ b/Libplanet.Seed/Libplanet.Seed.csproj
@@ -28,7 +28,7 @@
       </IncludeAssets>
     </PackageReference>
     <PackageReference Include="GraphQL" Version="2.4.0" />
-    <PackageReference Include="Libplanet.Net" Version="0.46.0" />
+    <PackageReference Include="Libplanet.Net" Version="0.53.4" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 


### PR DESCRIPTION
Since `Libplanet.Net:0.46.0` does not include messages on `gossip`, updated to `Libplanet.Net:0.53.4`.
Applied proper changes on message structure on `Libplanet.Net:0.53.4`.